### PR TITLE
Don’t use npm run to start the script

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd /app
-npm run -s main
+node lib/main.js


### PR DESCRIPTION
Starting script with `npm run` seems to add ~400ms to boot time. This PR will drop it